### PR TITLE
Added Compiler and Runtime Args to io bot

### DIFF
--- a/bot/plugins/instance.py
+++ b/bot/plugins/instance.py
@@ -225,12 +225,12 @@ def create_input_args_modal(
     comptime_modal_row = event.app.rest.build_modal_action_row()
     comptime_modal_row.add_text_input(
         "comptime",
-        "Comptime Args",
+        "Compiler Args",
         value=msg_instance.comptime_args or hikari.UNDEFINED,
         required=False,
         style=hikari.TextInputStyle.PARAGRAPH,
         max_length=255,
-        placeholder="Comptime Args - 1 per line",
+        placeholder="Compiler Args - 1 per line",
     )
 
     runtime_modal_row = event.app.rest.build_modal_action_row()

--- a/bot/plugins/instance.py
+++ b/bot/plugins/instance.py
@@ -220,6 +220,7 @@ def create_input_args_modal(
         value=msg_instance.stdin or hikari.UNDEFINED,
         required=False,
         style=hikari.TextInputStyle.PARAGRAPH,
+        max_length=1024,
         placeholder="Standard Input",
     )
 
@@ -230,6 +231,7 @@ def create_input_args_modal(
         value=msg_instance.comptime_args or hikari.UNDEFINED,
         required=False,
         style=hikari.TextInputStyle.PARAGRAPH,
+        max_length=255,
         placeholder="Command Line Parameters - 1 per line",
     )
 
@@ -240,6 +242,7 @@ def create_input_args_modal(
         value=msg_instance.runtime_args or hikari.UNDEFINED,
         required=False,
         style=hikari.TextInputStyle.PARAGRAPH,
+        max_length=255,
         placeholder="Command Line Parameters - 1 per line",
     )
 
@@ -526,11 +529,20 @@ class Instance:
             out.append("No runtime selected.")
 
         stdin = self.stdin or ""
-        formatted_stdin = "\n".join(
-            f"\x1b[1;33mIN:\x1b[0m {line}" for line in stdin.splitlines()
+        formatted_stdin = "\n".join(f"{line}" for line in stdin.splitlines())
+
+        comptime_args = self.comptime_args or ""
+        formatted_comptime_args = "\n".join(
+            f"{line}" for line in comptime_args.splitlines()
         )
 
-        if len(code_output) + len(formatted_stdin) > 1_950:
+        runtime_args = self.runtime_args or ""
+        formatted_runtime_args = "\n".join(
+            f"{line}" for line in runtime_args.splitlines()
+        )
+
+        message_length = len(code_output) + len(formatted_stdin)
+        if message_length > 1_950:
             if len(code_output) < 1_950:
                 stdin_in_file = True
             elif len(formatted_stdin) < 1_950:
@@ -549,7 +561,13 @@ class Instance:
             if stdin_in_file:
                 stdin_file = hikari.Bytes(stdin, "stdin.txt")
             else:
-                out.append(f"```ansi\n{formatted_stdin}```")
+                out.append(f"STDIN:\n```ansi\n{formatted_stdin}```")
+
+        if comptime_args:
+            out.append(f"COMPTIME ARGS:\n```ansi\n{formatted_comptime_args}```")
+
+        if runtime_args:
+            out.append(f"RUNTIME ARGS:\n```ansi\n{formatted_runtime_args}```")
 
         # send message
         out_str = "\n".join(out)

--- a/bot/plugins/instance.py
+++ b/bot/plugins/instance.py
@@ -536,10 +536,16 @@ class Instance:
             out.append(f"STDIN:\n```ansi\n{stdin}```")
 
         if comptime_args:
-            out.append(f"COMPTIME ARGS:\n```ansi\n{comptime_args}```")
+            warn = ""
+            if self.runtime and not self.runtime.provider.supports_compiler_args:
+                warn = " (Not supported by current runtime)"
+            out.append(f"Compiler Args{warn}:\n```ansi\n{comptime_args}```")
 
         if runtime_args:
-            out.append(f"RUNTIME ARGS:\n```ansi\n{runtime_args}```")
+            warn = ""
+            if self.runtime and not self.runtime.provider.supports_runtime_args:
+                warn = " (Not supported by current runtime)"
+            out.append(f"Runtime Args{warn}:\n```ansi\n{runtime_args}```")
 
         # send message
         out_str = "\n".join(out)

--- a/bot/providers/godbolt.py
+++ b/bot/providers/godbolt.py
@@ -94,8 +94,18 @@ class GodBolt(Provider):
             "lang": lang.lower(),
             "options": {
                 "compilerOptions": {"executorRequest": True},
-                "executeParameters": {"stdin": instance.stdin},
+                "executeParameters": {
+                    "stdin": instance.stdin,
+                    "args": (
+                        instance.runtime_args.splitlines()
+                        if instance.runtime_args is not None
+                        else []
+                    ),
+                },
                 "filters": {"execute": True},
+                "userArguments": instance.comptime_args.replace("\n", " ")
+                if instance.comptime_args is not None
+                else "",
             },
         }
 
@@ -134,6 +144,9 @@ class GodBolt(Provider):
                     "libraryCode": False,
                     "trim": False,
                 },
+                "userArguments": instance.comptime_args.replace("\n", " ")
+                if instance.comptime_args is not None
+                else "",
             },
         }
 

--- a/bot/providers/godbolt.py
+++ b/bot/providers/godbolt.py
@@ -46,6 +46,14 @@ def get_text(obj: object, *path: str) -> str | None:
 class GodBolt(Provider):
     URL = CONFIG.GODBOLT_URL
 
+    @property
+    def supports_compiler_args(self) -> bool:
+        return True
+
+    @property
+    def supports_runtime_args(self) -> bool:
+        return True
+
     async def startup(self) -> None:
         self._session = aiohttp.ClientSession(headers={"Accept": "application/json"})
 

--- a/bot/providers/piston.py
+++ b/bot/providers/piston.py
@@ -63,6 +63,9 @@ class Piston(Provider):
             "version": version,
             "files": [{"content": transform_code(lang, instance.code.code)}],
             "stdin": instance.stdin,
+            "args": instance.runtime_args.splitlines()
+            if instance.runtime_args is not None
+            else [],
         }
 
         async with self.session.post(self.URL + "execute", json=post_data) as resp:

--- a/bot/providers/piston.py
+++ b/bot/providers/piston.py
@@ -17,6 +17,14 @@ if t.TYPE_CHECKING:
 class Piston(Provider):
     URL = CONFIG.PISTON_URL
 
+    @property
+    def supports_compiler_args(self) -> bool:
+        return False
+
+    @property
+    def supports_runtime_args(self) -> bool:
+        return True
+
     def __init__(self, model: Model) -> None:
         self.aliases: dict[str, str] = {}
         super().__init__(model)

--- a/bot/providers/provider.py
+++ b/bot/providers/provider.py
@@ -18,6 +18,14 @@ class Provider(abc.ABC):
         self.runtimes = models.RuntimeTree()
         self._session: aiohttp.ClientSession | None = None
 
+    @abc.abstractproperty
+    def supports_compiler_args(self) -> bool:
+        ...
+
+    @abc.abstractproperty
+    def supports_runtime_args(self) -> bool:
+        ...
+
     @property
     def session(self) -> aiohttp.ClientSession:
         assert self._session, "aiohttp session not initialized"


### PR DESCRIPTION
- Added Compiler and Runtime Args to the io bot. This can be accessed from the `Set Inputs` button, previously called `Set STDIN`. 
- Made some minor modifications to the output of the code. The goal was to make it easy to copy someone's Compiler/Runtime args or STDIN. With the `IN: trag1c`, you'd have to manually erase the `IN: ` part.
![image](https://github.com/CircuitSacul/io/assets/65515165/eaf0b355-c847-42e8-a076-9e6ced91fefa)
- There is now a limit on the numbers of chars you enter. Following are the limits
- STDIN: 1024 chars
- COMPTIME ARGS: 255 chars
- RUNTIME ARGS: 255 chars
